### PR TITLE
fedora: Add wine for mingw build steps

### DIFF
--- a/fedora-mingw/Dockerfile
+++ b/fedora-mingw/Dockerfile
@@ -8,7 +8,8 @@ RUN dnf -y install \
   ccache \
   cmake \
   git \
-  ninja-build && \
+  ninja-build \
+  wine-core && \
   dnf clean all
 
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Shaderc in https://github.com/openblack/openblack/pull/114 needs to run with wine to compile directx shaders